### PR TITLE
Removing caption elements

### DIFF
--- a/_posts/2021-03-10-insights-into-https-only-mode.md
+++ b/_posts/2021-03-10-insights-into-https-only-mode.md
@@ -18,7 +18,9 @@ In a recent academic publication titled [HTTPS-Only: Upgrading all connections t
 
 The fundamental security problem of the current browser practice of defaulting to use insecure http, instead of secure https, when initially connecting to a website, is that attackers can intercept the initial request to a website. Hijacking the initial request suffices for an attacker to perform a man-in-the-middle attack, which in turn allows the attacker to downgrade the connection, eavesdrop or modify data sent between client and server.
 
-\[caption id="attachment\_207" align="aligncenter" width="600"\]![](/images/principle_approach-600x281.jpg) **Left:** The current standard behavior of browsers defaulting to http with a server reachable over https; **Right:** HTTPS-Only behaviour defaulting to https with fallback to http when a server is not reachable over https.\[/caption\]
+![](/images/principle_approach-600x281.jpg)
+
+**Left:** The current standard behavior of browsers defaulting to http with a server reachable over https; **Right:** HTTPS-Only behaviour defaulting to https with fallback to http when a server is not reachable over https.
 
  
 
@@ -46,7 +48,9 @@ Ultimately, HTTPS-Only also needs full integration with two critical browser sec
 
 The HTTPS-Only approach specifically aims to ensure connections use the secure https protocol, where browsers traditionally would connect using the http protocol. To target this data set, we record information when HTTPS-Only Mode is able to upgrade a connection by rewriting the scheme of a URL from http to https and a load succeeds.
 
-\[caption id="attachment\_208" align="aligncenter" width="486"\]![](/images/top-level-pie-chart-error-page-600x360.jpg) Attempts to upgrade top-level (document) legacy addresses from http to https via HTTPS-Only (data collected between Nov 17th and Dec. 17th 2020).\[/caption\]
+![](/images/top-level-pie-chart-error-page-600x360.jpg)
+
+Attempts to upgrade top-level (document) legacy addresses from http to https via HTTPS-Only (data collected between Nov 17th and Dec. 17th 2020).
 
  
 
@@ -54,7 +58,9 @@ As illustrated in the Figure above, the HTTPS-Only mechanism successfully upgrad
 
 Our observation that HTTPS-Only can successfully upgrade seven out of ten of top-level loads from http to https reflects a general migration of websites supporting https. At the same time, this fraction of successful upgrades of legacy addresses also confirms that web pages still contain a multitude of http-based URLs where browsers would traditionally establish an insecure connection.
 
-\[caption id="attachment\_209" align="aligncenter" width="600"\]![](/images/top-level-overview-pie-600x316.jpg) Use of https for top-level (document) loads when HTTPS-Only is enabled (data collected between Nov 17th and Dec. 17th 2020).\[/caption\]
+![](/images/top-level-overview-pie-600x316.jpg)
+
+Use of https for top-level (document) loads when HTTPS-Only is enabled (data collected between Nov 17th and Dec. 17th 2020).
 
  
 

--- a/_posts/2021-05-20-browser-fuzzing-at-mozilla.md
+++ b/_posts/2021-05-20-browser-fuzzing-at-mozilla.md
@@ -94,7 +94,9 @@ As in other fields, measurement is a key part of evaluating success. We leverage
 
 For example, the [meta bug for Domino](https://bugzilla.mozilla.org/show_bug.cgi?id=domino) lists all the issues (over 1100!) identified by this tool. Using this Bugzilla data, we are able to show the impact over the years of our various fuzzers.
 
-\[caption id="attachment\_47027" align="aligncenter" width="590"\]![Bar graph showing number of bugs reported by Domino over time](/images/Fuzzing-by-tools-Screenshot-221.svg) Number of bugs reported by Domino over time\[/caption\]
+![Bar graph showing number of bugs reported by Domino over time](/images/Fuzzing-by-tools-Screenshot-221.svg) 
+
+Number of bugs reported by Domino over time
 
 These dashboards help evaluate the return on investment of a fuzzer.
 


### PR DESCRIPTION
They are an artifact of wordpress->markdown export and are not supported by jekyll
